### PR TITLE
refactor(css): move body styles to _base.scss and remove _typography.scss

### DIFF
--- a/src/week2/css/base/_base.scss
+++ b/src/week2/css/base/_base.scss
@@ -1,5 +1,15 @@
+@use 'sass:map';
+@use '../abstracts/variables' as *;
+
 *,
 *::before,
 *::after {
   box-sizing: border-box;
+}
+
+body {
+  color: map.get($grays, "900");
+  line-height: $line-height-base;
+  font-family: "Noto Sans TC", -apple-system, BlinkMacSystemFont, "Segoe UI",
+    "Microsoft JhengHei", Roboto, "Helvetica Neue", Arial, sans-serif;
 }

--- a/src/week2/css/base/_typography.scss
+++ b/src/week2/css/base/_typography.scss
@@ -1,9 +1,0 @@
-@use "sass:map";
-@use '../abstracts/variables' as *;
-
-body {
-  color: map.get($grays, "900");
-  line-height: $line-height-base;
-  font-family: "Noto Sans TC", -apple-system, BlinkMacSystemFont, "Segoe UI",
-    "Microsoft JhengHei", Roboto, "Helvetica Neue", Arial, sans-serif;
-}

--- a/src/week2/css/product-list.scss
+++ b/src/week2/css/product-list.scss
@@ -6,7 +6,6 @@
 
 // 基底樣式
 @use 'base/base' as *;
-@use 'base/typography' as *;
 @use 'base/elements' as *;
 @use 'base/utilities' as *;
 

--- a/src/week2/css/product.scss
+++ b/src/week2/css/product.scss
@@ -6,7 +6,6 @@
 
 // 基底樣式
 @use 'base/base' as *;
-@use 'base/typography' as *;
 @use 'base/elements' as *;
 @use 'base/utilities' as *;
 


### PR DESCRIPTION
- Moved `body` styles from `_typography.scss` to `_base.scss`
- Removed `_typography.scss`
- Updated main SCSS file to stop importing `_typography.scss`