### PR TITLE
chore(ci): trigger deploy only when PR is merged into main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,12 +4,14 @@ permissions:
 name: Deploy to GitHub Pages
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches:
-      - main  # push main 就觸發
+      - main
 
 jobs:
   deploy:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Updated `deploy.yml` to run GitHub Actions only when a pull request is merged into the main branch